### PR TITLE
Changes ownership of a claim to its originating output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,8 @@ script:
   # Build Chainquery successfully
   - ./scripts/build.sh
   # Fail if a .go file hasn't been formatted with gofmt
-  - test -z $(gofmt -s -l $GO_FILES)
+  - gofmt -s -l -d $GO_FILES #List diff for debugging
+  - test -z $(gofmt -s -l -d $GO_FILES)
   - ./scripts/lint.sh
   # Run unit tests
   - ./scripts/test.sh

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -32,7 +32,7 @@ var runCmd = &cobra.Command{
 		job, ok := jobsMap[args[0]]
 		if !ok {
 			var jobs []string
-			for job, _ := range jobsMap {
+			for job := range jobsMap {
 				jobs = append(jobs, job)
 			}
 			logrus.Infof("Incorrect usage, should be: run <jobname>. Possible jobs are: %s", strings.Join(jobs, ", "))

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"log"
+	"strings"
+
+	"github.com/lbryio/chainquery/config"
+	"github.com/lbryio/chainquery/daemon/jobs"
+	"github.com/lbryio/chainquery/db"
+	"github.com/lbryio/chainquery/lbrycrd"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(runCmd)
+}
+
+var jobsMap = map[string]func(){
+	"claimtrie":        jobs.ClaimTrieSync,
+	"certificate":      jobs.CertificateSync,
+	"mempool":          jobs.MempoolSync,
+	"transactionvalue": jobs.TransactionValueSync,
+}
+
+var runCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Runs Specific Chainquery Jobs",
+	Long:  `Allows for running different chainquery jobs without having to run the rest of the application`,
+	Run: func(cmd *cobra.Command, args []string) {
+		job, ok := jobsMap[args[0]]
+		if !ok {
+			var jobs []string
+			for job, _ := range jobsMap {
+				jobs = append(jobs, job)
+			}
+			logrus.Infof("Incorrect usage, should be: run <jobname>. Possible jobs are: %s", strings.Join(jobs, ", "))
+			return
+		}
+		lbrycrdClient := lbrycrd.Init()
+		defer lbrycrdClient.Shutdown()
+		//Main Chainquery DB connection
+		dbInstance, err := db.Init(config.GetMySQLDSN(), config.GetDebugQueryMode())
+		if err != nil {
+			log.Panic(err)
+		}
+		job()
+
+		db.CloseDB(dbInstance)
+	},
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -68,7 +68,7 @@ func initJobs() {
 	scheduleJob(jobs.CertificateSync, "Certificate Sync", 5*time.Second)
 	scheduleJob(jobs.ValidateChain, "Validate Chain", 24*time.Hour)
 	scheduleJob(jobs.SyncAddressBalancesJob, "Address Balance Sync", 24*time.Hour)
-	scheduleJob(jobs.SyncTransactionValueJob, "Transaction Value Sync", 24*time.Hour)
+	scheduleJob(jobs.TransactionValueASync, "Transaction Value Sync", 24*time.Hour)
 }
 
 // ShutdownDaemon shuts the daemon down gracefully without corrupting the data.

--- a/daemon/jobs/valuesync.go
+++ b/daemon/jobs/valuesync.go
@@ -21,6 +21,8 @@ func SyncAddressBalancesJob() {
 	}()
 }
 
+//TransactionValueSync synchronizes the transaction value column due to a bug in mysql related to triggers.
+//https://bugs.mysql.com/bug.php?id=11472
 func TransactionValueSync() {
 	_, err := SyncTransactionValue()
 	if err != nil {
@@ -28,13 +30,13 @@ func TransactionValueSync() {
 	}
 }
 
-//SyncTransactionValueJob runs the SyncAddressBalances as a background job.
+//TransactionValueASync runs the SyncAddressBalances as a background job.
 func TransactionValueASync() {
 	go TransactionValueSync()
 }
 
 //SyncAddressBalances will update the balance for every address if needed based on the transaction address table and
-// returns the number of rows changed.
+// returns the number of rows changed. Due to mysql bug https://bugs.mysql.com/bug.php?id=11472
 func SyncAddressBalances() (int64, error) {
 
 	addressTbl := model.TableNames.Address

--- a/daemon/jobs/valuesync.go
+++ b/daemon/jobs/valuesync.go
@@ -21,14 +21,16 @@ func SyncAddressBalancesJob() {
 	}()
 }
 
+func TransactionValueSync() {
+	_, err := SyncTransactionValue()
+	if err != nil {
+		logrus.Error(syncTransactionValues, err)
+	}
+}
+
 //SyncTransactionValueJob runs the SyncAddressBalances as a background job.
-func SyncTransactionValueJob() {
-	go func() {
-		_, err := SyncTransactionValue()
-		if err != nil {
-			logrus.Error(syncTransactionValues, err)
-		}
-	}()
+func TransactionValueASync() {
+	go TransactionValueSync()
 }
 
 //SyncAddressBalances will update the balance for every address if needed based on the transaction address table and

--- a/daemon/processing/block.go
+++ b/daemon/processing/block.go
@@ -24,6 +24,7 @@ import (
 // BlockLock is used to lock block processing to a single parent thread.
 var BlockLock = sync.Mutex{}
 
+// ManualShutDownError Error with special handling. Used to stop the concurrency pipeline for processing blocks midway.
 var ManualShutDownError = errors.Err("Daemon stopped manually!")
 
 // RunBlockProcessing runs the processing of a block at a specific height. While any height can be passed in it is

--- a/daemon/processing/claim.go
+++ b/daemon/processing/claim.go
@@ -87,6 +87,8 @@ func processClaimNameScript(script *[]byte, vout model.Output, tx model.Transact
 	claim.Name = name
 	claim.TransactionTime = tx.TransactionTime
 	claim.ClaimAddress = lbrycrd.GetAddressFromPublicKeyScript(pkscript)
+	claim.TransactionHashUpdate.SetValid(tx.Hash)
+	claim.VoutUpdate.SetValid(vout.Vout)
 	if blockHeight > 0 {
 		claim.Height = uint(blockHeight)
 	} else {
@@ -144,8 +146,8 @@ func processClaimUpdateScript(script *[]byte, vout model.Output, tx model.Transa
 		} else {
 			logrus.Debug("ClaimUpdate: No blockheight!")
 		}
-		claim.TransactionHashID.SetValid(tx.Hash)
-		claim.Vout = vout.Vout
+		claim.TransactionHashUpdate.SetValid(tx.Hash)
+		claim.VoutUpdate.SetValid(vout.Vout)
 		if claim.BidState == "Spent" {
 			claim.BidState = "Accepted"
 		}

--- a/daemon/processing/outpoint.go
+++ b/daemon/processing/outpoint.go
@@ -224,6 +224,11 @@ func processVout(jsonVout *lbrycrd.Vout, tx *m.Transaction, txDC *txDebitCredits
 		if claim != nil {
 			vout.ClaimID.SetValid(claim.ClaimID)
 		}
+		// Save output with claim_id
+		err = ds.PutOutput(vout, boil.Infer())
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/lbrycrd/script.go
+++ b/lbrycrd/script.go
@@ -29,14 +29,15 @@ const (
 	opPushdata4    = 0x4e //opPushdata4 		= 78
 
 	// Types of vOut scripts
-	p2SH  = "scripthash" // Pay to Script Hash
-	p2PK  = "pubkey"     // Pay to Public Key
-	p2PKH = "pubkeyhash" // Pay to Public Key Hash
+	p2SH   = "scripthash"            // Pay to Script Hash
+	p2PK   = "pubkey"                // Pay to Public Key
+	p2PKH  = "pubkeyhash"            // Pay to Public Key Hash
+	p2WPKH = "witness_v0_keyhash"    //Segwit Pub Key Hash
+	p2WSH  = "witness_v0_scripthash" //Segwit Script Hash
 	// NonStandard is a transaction type, usually used for a claim.
-	NonStandard = "nonstandard" // Non Standard - Used for Claims in LBRY
-	NullData    = "nulldata"
-	P2WPKH_V0   = "witness_v0_keyhash"    //Segwit Pub Key Hash
-	P2WSH_V0    = "witness_v0_scripthash" //Segwit Script Hash
+	NonStandard = "nonstandard"
+	// NullData Transaction type related to segwit outputs
+	NullData = "nulldata"
 
 	lbrycrdMainPubkeyPrefix    = byte(85)
 	lbrycrdMainScriptPrefix    = byte(122)
@@ -283,9 +284,9 @@ func getPublicKeyScriptType(script []byte) string {
 	} else if isPayToScriptHashScript(script) {
 		return p2SH
 	} else if txscript.IsPayToWitnessPubKeyHash(script) {
-		return P2WPKH_V0
+		return p2WPKH
 	} else if txscript.IsPayToWitnessScriptHash(script) {
-		return P2WSH_V0
+		return p2WSH
 	}
 	return NonStandard
 }

--- a/migration/017_claim_owner.sql
+++ b/migration/017_claim_owner.sql
@@ -1,0 +1,17 @@
+-- +migrate Up
+
+-- +migrate StatementBegin
+ALTER TABLE claim
+    ADD COLUMN transaction_hash_update VARCHAR(70),
+    ADD COLUMN vout_update INT(10) UNSIGNED;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+ALTER TABLE claim
+    ADD INDEX (transaction_hash_update,vout_update);
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+UPDATE claim SET transaction_hash_update = transaction_hash_id, vout_update = vout;
+-- +migrate StatementEnd
+

--- a/model/claim.go
+++ b/model/claim.go
@@ -23,196 +23,202 @@ import (
 
 // Claim is an object representing the database table.
 type Claim struct {
-	ID                uint64      `boil:"id" json:"id" toml:"id" yaml:"id"`
-	TransactionHashID null.String `boil:"transaction_hash_id" json:"transaction_hash_id,omitempty" toml:"transaction_hash_id" yaml:"transaction_hash_id,omitempty"`
-	Vout              uint        `boil:"vout" json:"vout" toml:"vout" yaml:"vout"`
-	Name              string      `boil:"name" json:"name" toml:"name" yaml:"name"`
-	ClaimID           string      `boil:"claim_id" json:"claim_id" toml:"claim_id" yaml:"claim_id"`
-	ClaimType         int8        `boil:"claim_type" json:"claim_type" toml:"claim_type" yaml:"claim_type"`
-	PublisherID       null.String `boil:"publisher_id" json:"publisher_id,omitempty" toml:"publisher_id" yaml:"publisher_id,omitempty"`
-	PublisherSig      null.String `boil:"publisher_sig" json:"publisher_sig,omitempty" toml:"publisher_sig" yaml:"publisher_sig,omitempty"`
-	Certificate       null.String `boil:"certificate" json:"certificate,omitempty" toml:"certificate" yaml:"certificate,omitempty"`
-	SDHash            null.String `boil:"sd_hash" json:"sd_hash,omitempty" toml:"sd_hash" yaml:"sd_hash,omitempty"`
-	TransactionTime   null.Uint64 `boil:"transaction_time" json:"transaction_time,omitempty" toml:"transaction_time" yaml:"transaction_time,omitempty"`
-	Version           string      `boil:"version" json:"version" toml:"version" yaml:"version"`
-	ValueAsHex        string      `boil:"value_as_hex" json:"value_as_hex" toml:"value_as_hex" yaml:"value_as_hex"`
-	ValueAsJSON       null.String `boil:"value_as_json" json:"value_as_json,omitempty" toml:"value_as_json" yaml:"value_as_json,omitempty"`
-	ValidAtHeight     uint        `boil:"valid_at_height" json:"valid_at_height" toml:"valid_at_height" yaml:"valid_at_height"`
-	Height            uint        `boil:"height" json:"height" toml:"height" yaml:"height"`
-	EffectiveAmount   uint64      `boil:"effective_amount" json:"effective_amount" toml:"effective_amount" yaml:"effective_amount"`
-	Author            null.String `boil:"author" json:"author,omitempty" toml:"author" yaml:"author,omitempty"`
-	Description       null.String `boil:"description" json:"description,omitempty" toml:"description" yaml:"description,omitempty"`
-	ContentType       null.String `boil:"content_type" json:"content_type,omitempty" toml:"content_type" yaml:"content_type,omitempty"`
-	IsNSFW            bool        `boil:"is_nsfw" json:"is_nsfw" toml:"is_nsfw" yaml:"is_nsfw"`
-	Language          null.String `boil:"language" json:"language,omitempty" toml:"language" yaml:"language,omitempty"`
-	ThumbnailURL      null.String `boil:"thumbnail_url" json:"thumbnail_url,omitempty" toml:"thumbnail_url" yaml:"thumbnail_url,omitempty"`
-	Title             null.String `boil:"title" json:"title,omitempty" toml:"title" yaml:"title,omitempty"`
-	Fee               float64     `boil:"fee" json:"fee" toml:"fee" yaml:"fee"`
-	FeeCurrency       null.String `boil:"fee_currency" json:"fee_currency,omitempty" toml:"fee_currency" yaml:"fee_currency,omitempty"`
-	FeeAddress        string      `boil:"fee_address" json:"fee_address" toml:"fee_address" yaml:"fee_address"`
-	IsFiltered        bool        `boil:"is_filtered" json:"is_filtered" toml:"is_filtered" yaml:"is_filtered"`
-	BidState          string      `boil:"bid_state" json:"bid_state" toml:"bid_state" yaml:"bid_state"`
-	CreatedAt         time.Time   `boil:"created_at" json:"created_at" toml:"created_at" yaml:"created_at"`
-	ModifiedAt        time.Time   `boil:"modified_at" json:"modified_at" toml:"modified_at" yaml:"modified_at"`
-	ClaimAddress      string      `boil:"claim_address" json:"claim_address" toml:"claim_address" yaml:"claim_address"`
-	IsCertValid       bool        `boil:"is_cert_valid" json:"is_cert_valid" toml:"is_cert_valid" yaml:"is_cert_valid"`
-	IsCertProcessed   bool        `boil:"is_cert_processed" json:"is_cert_processed" toml:"is_cert_processed" yaml:"is_cert_processed"`
-	License           null.String `boil:"license" json:"license,omitempty" toml:"license" yaml:"license,omitempty"`
-	LicenseURL        null.String `boil:"license_url" json:"license_url,omitempty" toml:"license_url" yaml:"license_url,omitempty"`
-	Preview           null.String `boil:"preview" json:"preview,omitempty" toml:"preview" yaml:"preview,omitempty"`
-	Type              null.String `boil:"type" json:"type,omitempty" toml:"type" yaml:"type,omitempty"`
-	ReleaseTime       null.Uint64 `boil:"release_time" json:"release_time,omitempty" toml:"release_time" yaml:"release_time,omitempty"`
-	SourceHash        null.String `boil:"source_hash" json:"source_hash,omitempty" toml:"source_hash" yaml:"source_hash,omitempty"`
-	SourceName        null.String `boil:"source_name" json:"source_name,omitempty" toml:"source_name" yaml:"source_name,omitempty"`
-	SourceSize        null.Uint64 `boil:"source_size" json:"source_size,omitempty" toml:"source_size" yaml:"source_size,omitempty"`
-	SourceMediaType   null.String `boil:"source_media_type" json:"source_media_type,omitempty" toml:"source_media_type" yaml:"source_media_type,omitempty"`
-	SourceURL         null.String `boil:"source_url" json:"source_url,omitempty" toml:"source_url" yaml:"source_url,omitempty"`
-	FrameWidth        null.Uint64 `boil:"frame_width" json:"frame_width,omitempty" toml:"frame_width" yaml:"frame_width,omitempty"`
-	FrameHeight       null.Uint64 `boil:"frame_height" json:"frame_height,omitempty" toml:"frame_height" yaml:"frame_height,omitempty"`
-	Duration          null.Uint64 `boil:"duration" json:"duration,omitempty" toml:"duration" yaml:"duration,omitempty"`
-	AudioDuration     null.Uint64 `boil:"audio_duration" json:"audio_duration,omitempty" toml:"audio_duration" yaml:"audio_duration,omitempty"`
-	Os                null.String `boil:"os" json:"os,omitempty" toml:"os" yaml:"os,omitempty"`
-	Email             null.String `boil:"email" json:"email,omitempty" toml:"email" yaml:"email,omitempty"`
-	WebsiteURL        null.String `boil:"website_url" json:"website_url,omitempty" toml:"website_url" yaml:"website_url,omitempty"`
-	HasClaimList      null.Bool   `boil:"has_claim_list" json:"has_claim_list,omitempty" toml:"has_claim_list" yaml:"has_claim_list,omitempty"`
-	ClaimReference    null.String `boil:"claim_reference" json:"claim_reference,omitempty" toml:"claim_reference" yaml:"claim_reference,omitempty"`
-	ListType          null.Int16  `boil:"list_type" json:"list_type,omitempty" toml:"list_type" yaml:"list_type,omitempty"`
-	ClaimIDList       null.JSON   `boil:"claim_id_list" json:"claim_id_list,omitempty" toml:"claim_id_list" yaml:"claim_id_list,omitempty"`
-	Country           null.String `boil:"country" json:"country,omitempty" toml:"country" yaml:"country,omitempty"`
-	State             null.String `boil:"state" json:"state,omitempty" toml:"state" yaml:"state,omitempty"`
-	City              null.String `boil:"city" json:"city,omitempty" toml:"city" yaml:"city,omitempty"`
-	Code              null.String `boil:"code" json:"code,omitempty" toml:"code" yaml:"code,omitempty"`
-	Latitude          null.Int64  `boil:"latitude" json:"latitude,omitempty" toml:"latitude" yaml:"latitude,omitempty"`
-	Longitude         null.Int64  `boil:"longitude" json:"longitude,omitempty" toml:"longitude" yaml:"longitude,omitempty"`
+	ID                    uint64      `boil:"id" json:"id" toml:"id" yaml:"id"`
+	TransactionHashID     null.String `boil:"transaction_hash_id" json:"transaction_hash_id,omitempty" toml:"transaction_hash_id" yaml:"transaction_hash_id,omitempty"`
+	Vout                  uint        `boil:"vout" json:"vout" toml:"vout" yaml:"vout"`
+	Name                  string      `boil:"name" json:"name" toml:"name" yaml:"name"`
+	ClaimID               string      `boil:"claim_id" json:"claim_id" toml:"claim_id" yaml:"claim_id"`
+	ClaimType             int8        `boil:"claim_type" json:"claim_type" toml:"claim_type" yaml:"claim_type"`
+	PublisherID           null.String `boil:"publisher_id" json:"publisher_id,omitempty" toml:"publisher_id" yaml:"publisher_id,omitempty"`
+	PublisherSig          null.String `boil:"publisher_sig" json:"publisher_sig,omitempty" toml:"publisher_sig" yaml:"publisher_sig,omitempty"`
+	Certificate           null.String `boil:"certificate" json:"certificate,omitempty" toml:"certificate" yaml:"certificate,omitempty"`
+	SDHash                null.String `boil:"sd_hash" json:"sd_hash,omitempty" toml:"sd_hash" yaml:"sd_hash,omitempty"`
+	TransactionTime       null.Uint64 `boil:"transaction_time" json:"transaction_time,omitempty" toml:"transaction_time" yaml:"transaction_time,omitempty"`
+	Version               string      `boil:"version" json:"version" toml:"version" yaml:"version"`
+	ValueAsHex            string      `boil:"value_as_hex" json:"value_as_hex" toml:"value_as_hex" yaml:"value_as_hex"`
+	ValueAsJSON           null.String `boil:"value_as_json" json:"value_as_json,omitempty" toml:"value_as_json" yaml:"value_as_json,omitempty"`
+	ValidAtHeight         uint        `boil:"valid_at_height" json:"valid_at_height" toml:"valid_at_height" yaml:"valid_at_height"`
+	Height                uint        `boil:"height" json:"height" toml:"height" yaml:"height"`
+	EffectiveAmount       uint64      `boil:"effective_amount" json:"effective_amount" toml:"effective_amount" yaml:"effective_amount"`
+	Author                null.String `boil:"author" json:"author,omitempty" toml:"author" yaml:"author,omitempty"`
+	Description           null.String `boil:"description" json:"description,omitempty" toml:"description" yaml:"description,omitempty"`
+	ContentType           null.String `boil:"content_type" json:"content_type,omitempty" toml:"content_type" yaml:"content_type,omitempty"`
+	IsNSFW                bool        `boil:"is_nsfw" json:"is_nsfw" toml:"is_nsfw" yaml:"is_nsfw"`
+	Language              null.String `boil:"language" json:"language,omitempty" toml:"language" yaml:"language,omitempty"`
+	ThumbnailURL          null.String `boil:"thumbnail_url" json:"thumbnail_url,omitempty" toml:"thumbnail_url" yaml:"thumbnail_url,omitempty"`
+	Title                 null.String `boil:"title" json:"title,omitempty" toml:"title" yaml:"title,omitempty"`
+	Fee                   float64     `boil:"fee" json:"fee" toml:"fee" yaml:"fee"`
+	FeeCurrency           null.String `boil:"fee_currency" json:"fee_currency,omitempty" toml:"fee_currency" yaml:"fee_currency,omitempty"`
+	FeeAddress            string      `boil:"fee_address" json:"fee_address" toml:"fee_address" yaml:"fee_address"`
+	IsFiltered            bool        `boil:"is_filtered" json:"is_filtered" toml:"is_filtered" yaml:"is_filtered"`
+	BidState              string      `boil:"bid_state" json:"bid_state" toml:"bid_state" yaml:"bid_state"`
+	CreatedAt             time.Time   `boil:"created_at" json:"created_at" toml:"created_at" yaml:"created_at"`
+	ModifiedAt            time.Time   `boil:"modified_at" json:"modified_at" toml:"modified_at" yaml:"modified_at"`
+	ClaimAddress          string      `boil:"claim_address" json:"claim_address" toml:"claim_address" yaml:"claim_address"`
+	IsCertValid           bool        `boil:"is_cert_valid" json:"is_cert_valid" toml:"is_cert_valid" yaml:"is_cert_valid"`
+	IsCertProcessed       bool        `boil:"is_cert_processed" json:"is_cert_processed" toml:"is_cert_processed" yaml:"is_cert_processed"`
+	License               null.String `boil:"license" json:"license,omitempty" toml:"license" yaml:"license,omitempty"`
+	LicenseURL            null.String `boil:"license_url" json:"license_url,omitempty" toml:"license_url" yaml:"license_url,omitempty"`
+	Preview               null.String `boil:"preview" json:"preview,omitempty" toml:"preview" yaml:"preview,omitempty"`
+	Type                  null.String `boil:"type" json:"type,omitempty" toml:"type" yaml:"type,omitempty"`
+	ReleaseTime           null.Uint64 `boil:"release_time" json:"release_time,omitempty" toml:"release_time" yaml:"release_time,omitempty"`
+	SourceHash            null.String `boil:"source_hash" json:"source_hash,omitempty" toml:"source_hash" yaml:"source_hash,omitempty"`
+	SourceName            null.String `boil:"source_name" json:"source_name,omitempty" toml:"source_name" yaml:"source_name,omitempty"`
+	SourceSize            null.Uint64 `boil:"source_size" json:"source_size,omitempty" toml:"source_size" yaml:"source_size,omitempty"`
+	SourceMediaType       null.String `boil:"source_media_type" json:"source_media_type,omitempty" toml:"source_media_type" yaml:"source_media_type,omitempty"`
+	SourceURL             null.String `boil:"source_url" json:"source_url,omitempty" toml:"source_url" yaml:"source_url,omitempty"`
+	FrameWidth            null.Uint64 `boil:"frame_width" json:"frame_width,omitempty" toml:"frame_width" yaml:"frame_width,omitempty"`
+	FrameHeight           null.Uint64 `boil:"frame_height" json:"frame_height,omitempty" toml:"frame_height" yaml:"frame_height,omitempty"`
+	Duration              null.Uint64 `boil:"duration" json:"duration,omitempty" toml:"duration" yaml:"duration,omitempty"`
+	AudioDuration         null.Uint64 `boil:"audio_duration" json:"audio_duration,omitempty" toml:"audio_duration" yaml:"audio_duration,omitempty"`
+	Os                    null.String `boil:"os" json:"os,omitempty" toml:"os" yaml:"os,omitempty"`
+	Email                 null.String `boil:"email" json:"email,omitempty" toml:"email" yaml:"email,omitempty"`
+	WebsiteURL            null.String `boil:"website_url" json:"website_url,omitempty" toml:"website_url" yaml:"website_url,omitempty"`
+	HasClaimList          null.Bool   `boil:"has_claim_list" json:"has_claim_list,omitempty" toml:"has_claim_list" yaml:"has_claim_list,omitempty"`
+	ClaimReference        null.String `boil:"claim_reference" json:"claim_reference,omitempty" toml:"claim_reference" yaml:"claim_reference,omitempty"`
+	ListType              null.Int16  `boil:"list_type" json:"list_type,omitempty" toml:"list_type" yaml:"list_type,omitempty"`
+	ClaimIDList           null.JSON   `boil:"claim_id_list" json:"claim_id_list,omitempty" toml:"claim_id_list" yaml:"claim_id_list,omitempty"`
+	Country               null.String `boil:"country" json:"country,omitempty" toml:"country" yaml:"country,omitempty"`
+	State                 null.String `boil:"state" json:"state,omitempty" toml:"state" yaml:"state,omitempty"`
+	City                  null.String `boil:"city" json:"city,omitempty" toml:"city" yaml:"city,omitempty"`
+	Code                  null.String `boil:"code" json:"code,omitempty" toml:"code" yaml:"code,omitempty"`
+	Latitude              null.Int64  `boil:"latitude" json:"latitude,omitempty" toml:"latitude" yaml:"latitude,omitempty"`
+	Longitude             null.Int64  `boil:"longitude" json:"longitude,omitempty" toml:"longitude" yaml:"longitude,omitempty"`
+	TransactionHashUpdate null.String `boil:"transaction_hash_update" json:"transaction_hash_update,omitempty" toml:"transaction_hash_update" yaml:"transaction_hash_update,omitempty"`
+	VoutUpdate            null.Uint   `boil:"vout_update" json:"vout_update,omitempty" toml:"vout_update" yaml:"vout_update,omitempty"`
 
 	R *claimR `boil:"-" json:"-" toml:"-" yaml:"-"`
 	L claimL  `boil:"-" json:"-" toml:"-" yaml:"-"`
 }
 
 var ClaimColumns = struct {
-	ID                string
-	TransactionHashID string
-	Vout              string
-	Name              string
-	ClaimID           string
-	ClaimType         string
-	PublisherID       string
-	PublisherSig      string
-	Certificate       string
-	SDHash            string
-	TransactionTime   string
-	Version           string
-	ValueAsHex        string
-	ValueAsJSON       string
-	ValidAtHeight     string
-	Height            string
-	EffectiveAmount   string
-	Author            string
-	Description       string
-	ContentType       string
-	IsNSFW            string
-	Language          string
-	ThumbnailURL      string
-	Title             string
-	Fee               string
-	FeeCurrency       string
-	FeeAddress        string
-	IsFiltered        string
-	BidState          string
-	CreatedAt         string
-	ModifiedAt        string
-	ClaimAddress      string
-	IsCertValid       string
-	IsCertProcessed   string
-	License           string
-	LicenseURL        string
-	Preview           string
-	Type              string
-	ReleaseTime       string
-	SourceHash        string
-	SourceName        string
-	SourceSize        string
-	SourceMediaType   string
-	SourceURL         string
-	FrameWidth        string
-	FrameHeight       string
-	Duration          string
-	AudioDuration     string
-	Os                string
-	Email             string
-	WebsiteURL        string
-	HasClaimList      string
-	ClaimReference    string
-	ListType          string
-	ClaimIDList       string
-	Country           string
-	State             string
-	City              string
-	Code              string
-	Latitude          string
-	Longitude         string
+	ID                    string
+	TransactionHashID     string
+	Vout                  string
+	Name                  string
+	ClaimID               string
+	ClaimType             string
+	PublisherID           string
+	PublisherSig          string
+	Certificate           string
+	SDHash                string
+	TransactionTime       string
+	Version               string
+	ValueAsHex            string
+	ValueAsJSON           string
+	ValidAtHeight         string
+	Height                string
+	EffectiveAmount       string
+	Author                string
+	Description           string
+	ContentType           string
+	IsNSFW                string
+	Language              string
+	ThumbnailURL          string
+	Title                 string
+	Fee                   string
+	FeeCurrency           string
+	FeeAddress            string
+	IsFiltered            string
+	BidState              string
+	CreatedAt             string
+	ModifiedAt            string
+	ClaimAddress          string
+	IsCertValid           string
+	IsCertProcessed       string
+	License               string
+	LicenseURL            string
+	Preview               string
+	Type                  string
+	ReleaseTime           string
+	SourceHash            string
+	SourceName            string
+	SourceSize            string
+	SourceMediaType       string
+	SourceURL             string
+	FrameWidth            string
+	FrameHeight           string
+	Duration              string
+	AudioDuration         string
+	Os                    string
+	Email                 string
+	WebsiteURL            string
+	HasClaimList          string
+	ClaimReference        string
+	ListType              string
+	ClaimIDList           string
+	Country               string
+	State                 string
+	City                  string
+	Code                  string
+	Latitude              string
+	Longitude             string
+	TransactionHashUpdate string
+	VoutUpdate            string
 }{
-	ID:                "id",
-	TransactionHashID: "transaction_hash_id",
-	Vout:              "vout",
-	Name:              "name",
-	ClaimID:           "claim_id",
-	ClaimType:         "claim_type",
-	PublisherID:       "publisher_id",
-	PublisherSig:      "publisher_sig",
-	Certificate:       "certificate",
-	SDHash:            "sd_hash",
-	TransactionTime:   "transaction_time",
-	Version:           "version",
-	ValueAsHex:        "value_as_hex",
-	ValueAsJSON:       "value_as_json",
-	ValidAtHeight:     "valid_at_height",
-	Height:            "height",
-	EffectiveAmount:   "effective_amount",
-	Author:            "author",
-	Description:       "description",
-	ContentType:       "content_type",
-	IsNSFW:            "is_nsfw",
-	Language:          "language",
-	ThumbnailURL:      "thumbnail_url",
-	Title:             "title",
-	Fee:               "fee",
-	FeeCurrency:       "fee_currency",
-	FeeAddress:        "fee_address",
-	IsFiltered:        "is_filtered",
-	BidState:          "bid_state",
-	CreatedAt:         "created_at",
-	ModifiedAt:        "modified_at",
-	ClaimAddress:      "claim_address",
-	IsCertValid:       "is_cert_valid",
-	IsCertProcessed:   "is_cert_processed",
-	License:           "license",
-	LicenseURL:        "license_url",
-	Preview:           "preview",
-	Type:              "type",
-	ReleaseTime:       "release_time",
-	SourceHash:        "source_hash",
-	SourceName:        "source_name",
-	SourceSize:        "source_size",
-	SourceMediaType:   "source_media_type",
-	SourceURL:         "source_url",
-	FrameWidth:        "frame_width",
-	FrameHeight:       "frame_height",
-	Duration:          "duration",
-	AudioDuration:     "audio_duration",
-	Os:                "os",
-	Email:             "email",
-	WebsiteURL:        "website_url",
-	HasClaimList:      "has_claim_list",
-	ClaimReference:    "claim_reference",
-	ListType:          "list_type",
-	ClaimIDList:       "claim_id_list",
-	Country:           "country",
-	State:             "state",
-	City:              "city",
-	Code:              "code",
-	Latitude:          "latitude",
-	Longitude:         "longitude",
+	ID:                    "id",
+	TransactionHashID:     "transaction_hash_id",
+	Vout:                  "vout",
+	Name:                  "name",
+	ClaimID:               "claim_id",
+	ClaimType:             "claim_type",
+	PublisherID:           "publisher_id",
+	PublisherSig:          "publisher_sig",
+	Certificate:           "certificate",
+	SDHash:                "sd_hash",
+	TransactionTime:       "transaction_time",
+	Version:               "version",
+	ValueAsHex:            "value_as_hex",
+	ValueAsJSON:           "value_as_json",
+	ValidAtHeight:         "valid_at_height",
+	Height:                "height",
+	EffectiveAmount:       "effective_amount",
+	Author:                "author",
+	Description:           "description",
+	ContentType:           "content_type",
+	IsNSFW:                "is_nsfw",
+	Language:              "language",
+	ThumbnailURL:          "thumbnail_url",
+	Title:                 "title",
+	Fee:                   "fee",
+	FeeCurrency:           "fee_currency",
+	FeeAddress:            "fee_address",
+	IsFiltered:            "is_filtered",
+	BidState:              "bid_state",
+	CreatedAt:             "created_at",
+	ModifiedAt:            "modified_at",
+	ClaimAddress:          "claim_address",
+	IsCertValid:           "is_cert_valid",
+	IsCertProcessed:       "is_cert_processed",
+	License:               "license",
+	LicenseURL:            "license_url",
+	Preview:               "preview",
+	Type:                  "type",
+	ReleaseTime:           "release_time",
+	SourceHash:            "source_hash",
+	SourceName:            "source_name",
+	SourceSize:            "source_size",
+	SourceMediaType:       "source_media_type",
+	SourceURL:             "source_url",
+	FrameWidth:            "frame_width",
+	FrameHeight:           "frame_height",
+	Duration:              "duration",
+	AudioDuration:         "audio_duration",
+	Os:                    "os",
+	Email:                 "email",
+	WebsiteURL:            "website_url",
+	HasClaimList:          "has_claim_list",
+	ClaimReference:        "claim_reference",
+	ListType:              "list_type",
+	ClaimIDList:           "claim_id_list",
+	Country:               "country",
+	State:                 "state",
+	City:                  "city",
+	Code:                  "code",
+	Latitude:              "latitude",
+	Longitude:             "longitude",
+	TransactionHashUpdate: "transaction_hash_update",
+	VoutUpdate:            "vout_update",
 }
 
 // Generated where
@@ -341,130 +347,157 @@ func (w whereHelpernull_Int64) GTE(x null.Int64) qm.QueryMod {
 	return qmhelper.Where(w.field, qmhelper.GTE, x)
 }
 
+type whereHelpernull_Uint struct{ field string }
+
+func (w whereHelpernull_Uint) EQ(x null.Uint) qm.QueryMod {
+	return qmhelper.WhereNullEQ(w.field, false, x)
+}
+func (w whereHelpernull_Uint) NEQ(x null.Uint) qm.QueryMod {
+	return qmhelper.WhereNullEQ(w.field, true, x)
+}
+func (w whereHelpernull_Uint) IsNull() qm.QueryMod    { return qmhelper.WhereIsNull(w.field) }
+func (w whereHelpernull_Uint) IsNotNull() qm.QueryMod { return qmhelper.WhereIsNotNull(w.field) }
+func (w whereHelpernull_Uint) LT(x null.Uint) qm.QueryMod {
+	return qmhelper.Where(w.field, qmhelper.LT, x)
+}
+func (w whereHelpernull_Uint) LTE(x null.Uint) qm.QueryMod {
+	return qmhelper.Where(w.field, qmhelper.LTE, x)
+}
+func (w whereHelpernull_Uint) GT(x null.Uint) qm.QueryMod {
+	return qmhelper.Where(w.field, qmhelper.GT, x)
+}
+func (w whereHelpernull_Uint) GTE(x null.Uint) qm.QueryMod {
+	return qmhelper.Where(w.field, qmhelper.GTE, x)
+}
+
 var ClaimWhere = struct {
-	ID                whereHelperuint64
-	TransactionHashID whereHelpernull_String
-	Vout              whereHelperuint
-	Name              whereHelperstring
-	ClaimID           whereHelperstring
-	ClaimType         whereHelperint8
-	PublisherID       whereHelpernull_String
-	PublisherSig      whereHelpernull_String
-	Certificate       whereHelpernull_String
-	SDHash            whereHelpernull_String
-	TransactionTime   whereHelpernull_Uint64
-	Version           whereHelperstring
-	ValueAsHex        whereHelperstring
-	ValueAsJSON       whereHelpernull_String
-	ValidAtHeight     whereHelperuint
-	Height            whereHelperuint
-	EffectiveAmount   whereHelperuint64
-	Author            whereHelpernull_String
-	Description       whereHelpernull_String
-	ContentType       whereHelpernull_String
-	IsNSFW            whereHelperbool
-	Language          whereHelpernull_String
-	ThumbnailURL      whereHelpernull_String
-	Title             whereHelpernull_String
-	Fee               whereHelperfloat64
-	FeeCurrency       whereHelpernull_String
-	FeeAddress        whereHelperstring
-	IsFiltered        whereHelperbool
-	BidState          whereHelperstring
-	CreatedAt         whereHelpertime_Time
-	ModifiedAt        whereHelpertime_Time
-	ClaimAddress      whereHelperstring
-	IsCertValid       whereHelperbool
-	IsCertProcessed   whereHelperbool
-	License           whereHelpernull_String
-	LicenseURL        whereHelpernull_String
-	Preview           whereHelpernull_String
-	Type              whereHelpernull_String
-	ReleaseTime       whereHelpernull_Uint64
-	SourceHash        whereHelpernull_String
-	SourceName        whereHelpernull_String
-	SourceSize        whereHelpernull_Uint64
-	SourceMediaType   whereHelpernull_String
-	SourceURL         whereHelpernull_String
-	FrameWidth        whereHelpernull_Uint64
-	FrameHeight       whereHelpernull_Uint64
-	Duration          whereHelpernull_Uint64
-	AudioDuration     whereHelpernull_Uint64
-	Os                whereHelpernull_String
-	Email             whereHelpernull_String
-	WebsiteURL        whereHelpernull_String
-	HasClaimList      whereHelpernull_Bool
-	ClaimReference    whereHelpernull_String
-	ListType          whereHelpernull_Int16
-	ClaimIDList       whereHelpernull_JSON
-	Country           whereHelpernull_String
-	State             whereHelpernull_String
-	City              whereHelpernull_String
-	Code              whereHelpernull_String
-	Latitude          whereHelpernull_Int64
-	Longitude         whereHelpernull_Int64
+	ID                    whereHelperuint64
+	TransactionHashID     whereHelpernull_String
+	Vout                  whereHelperuint
+	Name                  whereHelperstring
+	ClaimID               whereHelperstring
+	ClaimType             whereHelperint8
+	PublisherID           whereHelpernull_String
+	PublisherSig          whereHelpernull_String
+	Certificate           whereHelpernull_String
+	SDHash                whereHelpernull_String
+	TransactionTime       whereHelpernull_Uint64
+	Version               whereHelperstring
+	ValueAsHex            whereHelperstring
+	ValueAsJSON           whereHelpernull_String
+	ValidAtHeight         whereHelperuint
+	Height                whereHelperuint
+	EffectiveAmount       whereHelperuint64
+	Author                whereHelpernull_String
+	Description           whereHelpernull_String
+	ContentType           whereHelpernull_String
+	IsNSFW                whereHelperbool
+	Language              whereHelpernull_String
+	ThumbnailURL          whereHelpernull_String
+	Title                 whereHelpernull_String
+	Fee                   whereHelperfloat64
+	FeeCurrency           whereHelpernull_String
+	FeeAddress            whereHelperstring
+	IsFiltered            whereHelperbool
+	BidState              whereHelperstring
+	CreatedAt             whereHelpertime_Time
+	ModifiedAt            whereHelpertime_Time
+	ClaimAddress          whereHelperstring
+	IsCertValid           whereHelperbool
+	IsCertProcessed       whereHelperbool
+	License               whereHelpernull_String
+	LicenseURL            whereHelpernull_String
+	Preview               whereHelpernull_String
+	Type                  whereHelpernull_String
+	ReleaseTime           whereHelpernull_Uint64
+	SourceHash            whereHelpernull_String
+	SourceName            whereHelpernull_String
+	SourceSize            whereHelpernull_Uint64
+	SourceMediaType       whereHelpernull_String
+	SourceURL             whereHelpernull_String
+	FrameWidth            whereHelpernull_Uint64
+	FrameHeight           whereHelpernull_Uint64
+	Duration              whereHelpernull_Uint64
+	AudioDuration         whereHelpernull_Uint64
+	Os                    whereHelpernull_String
+	Email                 whereHelpernull_String
+	WebsiteURL            whereHelpernull_String
+	HasClaimList          whereHelpernull_Bool
+	ClaimReference        whereHelpernull_String
+	ListType              whereHelpernull_Int16
+	ClaimIDList           whereHelpernull_JSON
+	Country               whereHelpernull_String
+	State                 whereHelpernull_String
+	City                  whereHelpernull_String
+	Code                  whereHelpernull_String
+	Latitude              whereHelpernull_Int64
+	Longitude             whereHelpernull_Int64
+	TransactionHashUpdate whereHelpernull_String
+	VoutUpdate            whereHelpernull_Uint
 }{
-	ID:                whereHelperuint64{field: "`claim`.`id`"},
-	TransactionHashID: whereHelpernull_String{field: "`claim`.`transaction_hash_id`"},
-	Vout:              whereHelperuint{field: "`claim`.`vout`"},
-	Name:              whereHelperstring{field: "`claim`.`name`"},
-	ClaimID:           whereHelperstring{field: "`claim`.`claim_id`"},
-	ClaimType:         whereHelperint8{field: "`claim`.`claim_type`"},
-	PublisherID:       whereHelpernull_String{field: "`claim`.`publisher_id`"},
-	PublisherSig:      whereHelpernull_String{field: "`claim`.`publisher_sig`"},
-	Certificate:       whereHelpernull_String{field: "`claim`.`certificate`"},
-	SDHash:            whereHelpernull_String{field: "`claim`.`sd_hash`"},
-	TransactionTime:   whereHelpernull_Uint64{field: "`claim`.`transaction_time`"},
-	Version:           whereHelperstring{field: "`claim`.`version`"},
-	ValueAsHex:        whereHelperstring{field: "`claim`.`value_as_hex`"},
-	ValueAsJSON:       whereHelpernull_String{field: "`claim`.`value_as_json`"},
-	ValidAtHeight:     whereHelperuint{field: "`claim`.`valid_at_height`"},
-	Height:            whereHelperuint{field: "`claim`.`height`"},
-	EffectiveAmount:   whereHelperuint64{field: "`claim`.`effective_amount`"},
-	Author:            whereHelpernull_String{field: "`claim`.`author`"},
-	Description:       whereHelpernull_String{field: "`claim`.`description`"},
-	ContentType:       whereHelpernull_String{field: "`claim`.`content_type`"},
-	IsNSFW:            whereHelperbool{field: "`claim`.`is_nsfw`"},
-	Language:          whereHelpernull_String{field: "`claim`.`language`"},
-	ThumbnailURL:      whereHelpernull_String{field: "`claim`.`thumbnail_url`"},
-	Title:             whereHelpernull_String{field: "`claim`.`title`"},
-	Fee:               whereHelperfloat64{field: "`claim`.`fee`"},
-	FeeCurrency:       whereHelpernull_String{field: "`claim`.`fee_currency`"},
-	FeeAddress:        whereHelperstring{field: "`claim`.`fee_address`"},
-	IsFiltered:        whereHelperbool{field: "`claim`.`is_filtered`"},
-	BidState:          whereHelperstring{field: "`claim`.`bid_state`"},
-	CreatedAt:         whereHelpertime_Time{field: "`claim`.`created_at`"},
-	ModifiedAt:        whereHelpertime_Time{field: "`claim`.`modified_at`"},
-	ClaimAddress:      whereHelperstring{field: "`claim`.`claim_address`"},
-	IsCertValid:       whereHelperbool{field: "`claim`.`is_cert_valid`"},
-	IsCertProcessed:   whereHelperbool{field: "`claim`.`is_cert_processed`"},
-	License:           whereHelpernull_String{field: "`claim`.`license`"},
-	LicenseURL:        whereHelpernull_String{field: "`claim`.`license_url`"},
-	Preview:           whereHelpernull_String{field: "`claim`.`preview`"},
-	Type:              whereHelpernull_String{field: "`claim`.`type`"},
-	ReleaseTime:       whereHelpernull_Uint64{field: "`claim`.`release_time`"},
-	SourceHash:        whereHelpernull_String{field: "`claim`.`source_hash`"},
-	SourceName:        whereHelpernull_String{field: "`claim`.`source_name`"},
-	SourceSize:        whereHelpernull_Uint64{field: "`claim`.`source_size`"},
-	SourceMediaType:   whereHelpernull_String{field: "`claim`.`source_media_type`"},
-	SourceURL:         whereHelpernull_String{field: "`claim`.`source_url`"},
-	FrameWidth:        whereHelpernull_Uint64{field: "`claim`.`frame_width`"},
-	FrameHeight:       whereHelpernull_Uint64{field: "`claim`.`frame_height`"},
-	Duration:          whereHelpernull_Uint64{field: "`claim`.`duration`"},
-	AudioDuration:     whereHelpernull_Uint64{field: "`claim`.`audio_duration`"},
-	Os:                whereHelpernull_String{field: "`claim`.`os`"},
-	Email:             whereHelpernull_String{field: "`claim`.`email`"},
-	WebsiteURL:        whereHelpernull_String{field: "`claim`.`website_url`"},
-	HasClaimList:      whereHelpernull_Bool{field: "`claim`.`has_claim_list`"},
-	ClaimReference:    whereHelpernull_String{field: "`claim`.`claim_reference`"},
-	ListType:          whereHelpernull_Int16{field: "`claim`.`list_type`"},
-	ClaimIDList:       whereHelpernull_JSON{field: "`claim`.`claim_id_list`"},
-	Country:           whereHelpernull_String{field: "`claim`.`country`"},
-	State:             whereHelpernull_String{field: "`claim`.`state`"},
-	City:              whereHelpernull_String{field: "`claim`.`city`"},
-	Code:              whereHelpernull_String{field: "`claim`.`code`"},
-	Latitude:          whereHelpernull_Int64{field: "`claim`.`latitude`"},
-	Longitude:         whereHelpernull_Int64{field: "`claim`.`longitude`"},
+	ID:                    whereHelperuint64{field: "`claim`.`id`"},
+	TransactionHashID:     whereHelpernull_String{field: "`claim`.`transaction_hash_id`"},
+	Vout:                  whereHelperuint{field: "`claim`.`vout`"},
+	Name:                  whereHelperstring{field: "`claim`.`name`"},
+	ClaimID:               whereHelperstring{field: "`claim`.`claim_id`"},
+	ClaimType:             whereHelperint8{field: "`claim`.`claim_type`"},
+	PublisherID:           whereHelpernull_String{field: "`claim`.`publisher_id`"},
+	PublisherSig:          whereHelpernull_String{field: "`claim`.`publisher_sig`"},
+	Certificate:           whereHelpernull_String{field: "`claim`.`certificate`"},
+	SDHash:                whereHelpernull_String{field: "`claim`.`sd_hash`"},
+	TransactionTime:       whereHelpernull_Uint64{field: "`claim`.`transaction_time`"},
+	Version:               whereHelperstring{field: "`claim`.`version`"},
+	ValueAsHex:            whereHelperstring{field: "`claim`.`value_as_hex`"},
+	ValueAsJSON:           whereHelpernull_String{field: "`claim`.`value_as_json`"},
+	ValidAtHeight:         whereHelperuint{field: "`claim`.`valid_at_height`"},
+	Height:                whereHelperuint{field: "`claim`.`height`"},
+	EffectiveAmount:       whereHelperuint64{field: "`claim`.`effective_amount`"},
+	Author:                whereHelpernull_String{field: "`claim`.`author`"},
+	Description:           whereHelpernull_String{field: "`claim`.`description`"},
+	ContentType:           whereHelpernull_String{field: "`claim`.`content_type`"},
+	IsNSFW:                whereHelperbool{field: "`claim`.`is_nsfw`"},
+	Language:              whereHelpernull_String{field: "`claim`.`language`"},
+	ThumbnailURL:          whereHelpernull_String{field: "`claim`.`thumbnail_url`"},
+	Title:                 whereHelpernull_String{field: "`claim`.`title`"},
+	Fee:                   whereHelperfloat64{field: "`claim`.`fee`"},
+	FeeCurrency:           whereHelpernull_String{field: "`claim`.`fee_currency`"},
+	FeeAddress:            whereHelperstring{field: "`claim`.`fee_address`"},
+	IsFiltered:            whereHelperbool{field: "`claim`.`is_filtered`"},
+	BidState:              whereHelperstring{field: "`claim`.`bid_state`"},
+	CreatedAt:             whereHelpertime_Time{field: "`claim`.`created_at`"},
+	ModifiedAt:            whereHelpertime_Time{field: "`claim`.`modified_at`"},
+	ClaimAddress:          whereHelperstring{field: "`claim`.`claim_address`"},
+	IsCertValid:           whereHelperbool{field: "`claim`.`is_cert_valid`"},
+	IsCertProcessed:       whereHelperbool{field: "`claim`.`is_cert_processed`"},
+	License:               whereHelpernull_String{field: "`claim`.`license`"},
+	LicenseURL:            whereHelpernull_String{field: "`claim`.`license_url`"},
+	Preview:               whereHelpernull_String{field: "`claim`.`preview`"},
+	Type:                  whereHelpernull_String{field: "`claim`.`type`"},
+	ReleaseTime:           whereHelpernull_Uint64{field: "`claim`.`release_time`"},
+	SourceHash:            whereHelpernull_String{field: "`claim`.`source_hash`"},
+	SourceName:            whereHelpernull_String{field: "`claim`.`source_name`"},
+	SourceSize:            whereHelpernull_Uint64{field: "`claim`.`source_size`"},
+	SourceMediaType:       whereHelpernull_String{field: "`claim`.`source_media_type`"},
+	SourceURL:             whereHelpernull_String{field: "`claim`.`source_url`"},
+	FrameWidth:            whereHelpernull_Uint64{field: "`claim`.`frame_width`"},
+	FrameHeight:           whereHelpernull_Uint64{field: "`claim`.`frame_height`"},
+	Duration:              whereHelpernull_Uint64{field: "`claim`.`duration`"},
+	AudioDuration:         whereHelpernull_Uint64{field: "`claim`.`audio_duration`"},
+	Os:                    whereHelpernull_String{field: "`claim`.`os`"},
+	Email:                 whereHelpernull_String{field: "`claim`.`email`"},
+	WebsiteURL:            whereHelpernull_String{field: "`claim`.`website_url`"},
+	HasClaimList:          whereHelpernull_Bool{field: "`claim`.`has_claim_list`"},
+	ClaimReference:        whereHelpernull_String{field: "`claim`.`claim_reference`"},
+	ListType:              whereHelpernull_Int16{field: "`claim`.`list_type`"},
+	ClaimIDList:           whereHelpernull_JSON{field: "`claim`.`claim_id_list`"},
+	Country:               whereHelpernull_String{field: "`claim`.`country`"},
+	State:                 whereHelpernull_String{field: "`claim`.`state`"},
+	City:                  whereHelpernull_String{field: "`claim`.`city`"},
+	Code:                  whereHelpernull_String{field: "`claim`.`code`"},
+	Latitude:              whereHelpernull_Int64{field: "`claim`.`latitude`"},
+	Longitude:             whereHelpernull_Int64{field: "`claim`.`longitude`"},
+	TransactionHashUpdate: whereHelpernull_String{field: "`claim`.`transaction_hash_update`"},
+	VoutUpdate:            whereHelpernull_Uint{field: "`claim`.`vout_update`"},
 }
 
 // ClaimRels is where relationship names are stored.
@@ -494,8 +527,8 @@ func (*claimR) NewStruct() *claimR {
 type claimL struct{}
 
 var (
-	claimAllColumns            = []string{"id", "transaction_hash_id", "vout", "name", "claim_id", "claim_type", "publisher_id", "publisher_sig", "certificate", "sd_hash", "transaction_time", "version", "value_as_hex", "value_as_json", "valid_at_height", "height", "effective_amount", "author", "description", "content_type", "is_nsfw", "language", "thumbnail_url", "title", "fee", "fee_currency", "fee_address", "is_filtered", "bid_state", "created_at", "modified_at", "claim_address", "is_cert_valid", "is_cert_processed", "license", "license_url", "preview", "type", "release_time", "source_hash", "source_name", "source_size", "source_media_type", "source_url", "frame_width", "frame_height", "duration", "audio_duration", "os", "email", "website_url", "has_claim_list", "claim_reference", "list_type", "claim_id_list", "country", "state", "city", "code", "latitude", "longitude"}
-	claimColumnsWithoutDefault = []string{"transaction_hash_id", "vout", "name", "claim_id", "claim_type", "publisher_id", "publisher_sig", "certificate", "sd_hash", "transaction_time", "version", "value_as_hex", "value_as_json", "valid_at_height", "height", "author", "description", "content_type", "language", "thumbnail_url", "title", "fee_currency", "fee_address", "claim_address", "is_cert_valid", "is_cert_processed", "license", "license_url", "preview", "type", "release_time", "source_hash", "source_name", "source_size", "source_media_type", "source_url", "frame_width", "frame_height", "duration", "audio_duration", "os", "email", "website_url", "has_claim_list", "claim_reference", "list_type", "claim_id_list", "country", "state", "city", "code", "latitude", "longitude"}
+	claimAllColumns            = []string{"id", "transaction_hash_id", "vout", "name", "claim_id", "claim_type", "publisher_id", "publisher_sig", "certificate", "sd_hash", "transaction_time", "version", "value_as_hex", "value_as_json", "valid_at_height", "height", "effective_amount", "author", "description", "content_type", "is_nsfw", "language", "thumbnail_url", "title", "fee", "fee_currency", "fee_address", "is_filtered", "bid_state", "created_at", "modified_at", "claim_address", "is_cert_valid", "is_cert_processed", "license", "license_url", "preview", "type", "release_time", "source_hash", "source_name", "source_size", "source_media_type", "source_url", "frame_width", "frame_height", "duration", "audio_duration", "os", "email", "website_url", "has_claim_list", "claim_reference", "list_type", "claim_id_list", "country", "state", "city", "code", "latitude", "longitude", "transaction_hash_update", "vout_update"}
+	claimColumnsWithoutDefault = []string{"transaction_hash_id", "vout", "name", "claim_id", "claim_type", "publisher_id", "publisher_sig", "certificate", "sd_hash", "transaction_time", "version", "value_as_hex", "value_as_json", "valid_at_height", "height", "author", "description", "content_type", "language", "thumbnail_url", "title", "fee_currency", "fee_address", "claim_address", "is_cert_valid", "is_cert_processed", "license", "license_url", "preview", "type", "release_time", "source_hash", "source_name", "source_size", "source_media_type", "source_url", "frame_width", "frame_height", "duration", "audio_duration", "os", "email", "website_url", "has_claim_list", "claim_reference", "list_type", "claim_id_list", "country", "state", "city", "code", "latitude", "longitude", "transaction_hash_update", "vout_update"}
 	claimColumnsWithDefault    = []string{"id", "effective_amount", "is_nsfw", "fee", "is_filtered", "bid_state", "created_at", "modified_at"}
 	claimPrimaryKeyColumns     = []string{"id"}
 )

--- a/model/input.go
+++ b/model/input.go
@@ -85,29 +85,6 @@ var InputColumns = struct {
 
 // Generated where
 
-type whereHelpernull_Uint struct{ field string }
-
-func (w whereHelpernull_Uint) EQ(x null.Uint) qm.QueryMod {
-	return qmhelper.WhereNullEQ(w.field, false, x)
-}
-func (w whereHelpernull_Uint) NEQ(x null.Uint) qm.QueryMod {
-	return qmhelper.WhereNullEQ(w.field, true, x)
-}
-func (w whereHelpernull_Uint) IsNull() qm.QueryMod    { return qmhelper.WhereIsNull(w.field) }
-func (w whereHelpernull_Uint) IsNotNull() qm.QueryMod { return qmhelper.WhereIsNotNull(w.field) }
-func (w whereHelpernull_Uint) LT(x null.Uint) qm.QueryMod {
-	return qmhelper.Where(w.field, qmhelper.LT, x)
-}
-func (w whereHelpernull_Uint) LTE(x null.Uint) qm.QueryMod {
-	return qmhelper.Where(w.field, qmhelper.LTE, x)
-}
-func (w whereHelpernull_Uint) GT(x null.Uint) qm.QueryMod {
-	return qmhelper.Where(w.field, qmhelper.GT, x)
-}
-func (w whereHelpernull_Uint) GTE(x null.Uint) qm.QueryMod {
-	return qmhelper.Where(w.field, qmhelper.GTE, x)
-}
-
 type whereHelpernull_Float64 struct{ field string }
 
 func (w whereHelpernull_Float64) EQ(x null.Float64) qm.QueryMod {

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -29,5 +29,5 @@ echo "Running gocyclo..." && gocyclo -ignore "_test" -avg -over 19 $GO_FILES
 # forbid code with huge functions
 # "go vet on steroids" + linter - ignore autogen code
 # one last linter - ignore autogen code
-#echo "Running golint..." && golint -set_exit_status $(go list ./... | grep -v /vendor/ | grep -v /model/ | grep -v /migration )
+echo "Running golint..." && golint -set_exit_status $(go list ./... | grep -v /vendor/ | grep -v /model/ | grep -v /swagger/ | grep -v /migration )
 test $err = 0 # Return non-zero if any command failed


### PR DESCRIPTION
FIX update spent claims bug where nothing gets updated
FIX bug where claim_id was never getting set on the output when processed
ADD run command to run individual chainquery jobs instead of the whole application
ADD new columns to track against the latest utxo applied to a claim
CHANGE name of transaction value sync function name for alignment
CHANGE owner of claims to be the first output that creates it instead of the latest output that updates it
CHANGE claim trie sync to consider the latest utxo for whether its spent

This is a breaking change (2.0) to the Chainquery database schema. The `transaction_hash_id` and the `vout` column on a claim now refer to the `transaction` and `output` of its origination. Any updates to the claim, include its origination will update the `transaction_hash_update` and `vout_update` columns respectively. 

@tzarebczan (anything else you can think of?), @akinwale (explorer), @jessopb (spee.ch)