### PR TITLE
Force license string sanitization

### DIFF
--- a/daemon/processing/claim.go
+++ b/daemon/processing/claim.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/lbryio/lbryschema.go/address/base58"
@@ -351,6 +352,11 @@ func setTags(claim *model.Claim, tags []string) error {
 
 func setLicense(claim *model.Claim, stream pb.Stream) {
 	license := stream.GetLicense()
+	
+	// Sanitize string
+	if license != "" {
+		license = strings.ToValidUTF8(license, "")
+	}
 	if len([]rune(license)) > 500 {
 		license = string([]rune(license)[:500])
 	}


### PR DESCRIPTION
Just added a basic sanitization for the license string.
It is unclear to me why is this needed for this field and not for other similar fields like `description`. 

> ToValidUTF8 returns a copy of the string s with each run of invalid UTF-8 byte sequences replaced by the replacement string, which may be empty.
> https://golang.org/pkg/strings/#ToValidUTF8

I created a simple reproducible test: https://play.golang.org/p/UePIqVsRbCS

If this fixes the issue then this should not longer return null on the license:

https://chainquery.lbry.com/api/sql?query=%20Select%20license%20from%20claim%20where%20claim_id%20=%20%229c20eec1c3d2069cfe9ba20b12e2f7fd56de4af1%22

If the license still  is null or an empty sting "" then this is returning a full invalid string:

https://github.com/lbryio/chainquery/blob/f8ecd466eb0bc927c2669c0ee30b6e2e737d4493/daemon/processing/claim.go#L353

This is the current expected value:
```
license: "All rights reserved" 
```